### PR TITLE
Speed up ESP32 flashing

### DIFF
--- a/app/src/main/java/com/altimeter/bdureau/bearconsole/Flash/CommandInterfaceESP32.java
+++ b/app/src/main/java/com/altimeter/bdureau/bearconsole/Flash/CommandInterfaceESP32.java
@@ -235,27 +235,35 @@ public class CommandInterfaceESP32 {
         byte buf[] = slipEncode(data);
 
         ret = mPhysicaloid.write(buf, buf.length);
-        try { Thread.sleep(timeout); } catch (InterruptedException e) {}
-
-            int numRead =recv(retVal.retValue, retVal.retValue.length, timeout);
-            mUpCallback.onInfo("num read:" + numRead);
+        try { Thread.sleep(5); } catch (InterruptedException e) {}
+        
+        int numRead = 0;
+        
+        for (i = 0; i < 10; i++) {
+            numRead = recv(retVal.retValue, retVal.retValue.length, timeout/10);
+            // mUpCallback.onInfo("num read:" + numRead);
             if (numRead == 0) {
                 retVal.retCode = -1;
+                continue;
             } else if (numRead == -1) {
                 retVal.retCode = -1;
+                continue;
             }
 
             if (retVal.retValue[0] != (byte) 0xC0) {
                 //mUpCallback.onInfo("invalid packet\n");
                 // System.out.println("Packet: " + printHex(retVal.retValue));
                 retVal.retCode = -1;
+                continue;
             }
 
             if (retVal.retValue[0] == (byte) 0xC0) {
                 mUpCallback.onInfo("This is correct!!!\n");
                 // System.out.println("Packet: " + printHex(retVal.retValue));
                 retVal.retCode = 1;
+                break;
             }
+        }
 
         return retVal;
     }
@@ -277,7 +285,8 @@ public class CommandInterfaceESP32 {
                 //    Log.d(TAG, "recv(" + retval + ") : " + toHexStr(buf, totalRetval));
                 //}
             }
-            if (totalRetval >= length) {
+            
+            if (totalRetval >= 8) { 
                 break;
             }
 


### PR DESCRIPTION
First of all, thanks for your code, this is very helpful! I made a change to try speed up the flashing process, I hope you like it

This change can save up to 195ms per flash write: 95ms of delay before read and up to 100ms reading ESP32 response. 
For example, using a 1MB firmware file and considering current FLASH_WRITE_SIZE = 0x400, it requires 1000 flash writes. So in theory, will flash 195 seconds faster. In practice a bit less, due ESP32 response times

As a drawback, it may break compatibility with some old ESP8266 chips